### PR TITLE
Remove CreateLogGroup permission from service role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,6 @@ data "aws_iam_policy_document" "assume_role_policy" {
 data "aws_iam_policy_document" "role_policy" {
   statement {
     actions = [
-      "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
       "logs:DescribeLogGroups",


### PR DESCRIPTION
This permission is not needed because we create the log group with Terraform so the VPC Flow Logs service doesn’t need to do it. On the other hand having this permission causes a bug where, on `terraform destroy` the log group will be destroyed, but then if there is still a few messages in a VPC Flow Logs queue the managed service will see that the log group does not exist and create it again using.

You’ll then have the log group lingering after the tf destroy, which can cause trouble if you try to `terraform apply` again with the same name: the log group will be already existing and your apply will fail. Not having the permission prevents that as the managed service will not be able to recreate the log group after the tf destroy.