### PR TITLE
Adding tag functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ module "vpc_flow_logs" {
 | logs\_retention | Number of days you want to retain log events in the log group. | `number` | `90` | no |
 | vpc\_id | VPC ID to attach to. | `string` | n/a | yes |
 | vpc\_name | The VPC name is used to name the flow log resources. | `string` | n/a | yes |
+| tags | A standard map of optional tags to add to the log group for billing purposes. | `map(string)` | n/a | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,9 @@ resource "aws_flow_log" "main" {
 resource "aws_cloudwatch_log_group" "main" {
   name              = "vpc-flow-logs-${var.vpc_name}"
   retention_in_days = var.logs_retention
+
+  tags = var.tags
+
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -12,3 +12,9 @@ variable "logs_retention" {
   description = "Number of days you want to retain log events in the log group."
   default     = 90
 }
+
+variable "tags" {
+  description = "A mapping of tags to assign to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Simple bog standard add of tags to the CloudWatch log group resource. Useful if your organization wants billed resources to be tracked. 